### PR TITLE
 Improve parser for better rendering of index.html file

### DIFF
--- a/starfyre/__init__.py
+++ b/starfyre/__init__.py
@@ -8,7 +8,7 @@ from .transpiler import transpile
 from .parser import RootParser
 
 
-def create_component(pyml="", css="", js="", client_side_python=""):
+def create_component(pyml="", css="", js="", client_side_python="", class_name=""):
     if client_side_python:
         new_js = transpile(client_side_python) + js
         js = new_js
@@ -16,7 +16,7 @@ def create_component(pyml="", css="", js="", client_side_python=""):
     local_variables = inspect.currentframe().f_back.f_back.f_locals.copy()
     global_variables = inspect.currentframe().f_back.f_back.f_globals.copy()
 
-    parser = RootParser(local_variables, global_variables, css, js)
+    parser = RootParser(local_variables, global_variables, css, js, class_name)
     pyml = pyml.strip("\n").strip()
     parser.feed(pyml)
     parser.close()

--- a/starfyre/__init__.py
+++ b/starfyre/__init__.py
@@ -8,7 +8,7 @@ from .transpiler import transpile
 from .parser import RootParser
 
 
-def create_component(pyml="", css="", js="", client_side_python="", class_name=""):
+def create_component(pyml="", css="", js="", client_side_python="", component_name=""):
     if client_side_python:
         new_js = transpile(client_side_python) + js
         js = new_js
@@ -16,7 +16,7 @@ def create_component(pyml="", css="", js="", client_side_python="", class_name="
     local_variables = inspect.currentframe().f_back.f_back.f_locals.copy()
     global_variables = inspect.currentframe().f_back.f_back.f_globals.copy()
 
-    parser = RootParser(local_variables, global_variables, css, js, class_name)
+    parser = RootParser(local_variables, global_variables, css, js, component_name)
     pyml = pyml.strip("\n").strip()
     parser.feed(pyml)
     parser.close()

--- a/starfyre/__main__.py
+++ b/starfyre/__main__.py
@@ -63,6 +63,7 @@ def main(path, build):
     if build:
         # Compile and build project
         init_file_path = absolute_path / "__init__.py"
+      
         compile(init_file_path.resolve())
         create_main_file(str(absolute_path))
 
@@ -71,7 +72,7 @@ def main(path, build):
             [sys.executable, "-m", "build"],
             cwd=path,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=None,
         )
 
 

--- a/starfyre/compiler.py
+++ b/starfyre/compiler.py
@@ -127,7 +127,8 @@ def fx_{root_name}():
 {js_lines}
 """, client_side_python="""
 {client_side_python}
-"""
+""",
+class_name="""{root_name}"""
 )
     return render_root(component)
 
@@ -146,7 +147,8 @@ def fx_{root_name}():
 {js_lines}
 """, client_side_python="""
 {client_side_python}
-"""
+""",
+class_name="""{root_name}"""
 )
     return component
 

--- a/starfyre/compiler.py
+++ b/starfyre/compiler.py
@@ -128,7 +128,7 @@ def fx_{root_name}():
 """, client_side_python="""
 {client_side_python}
 """,
-class_name="""{root_name}"""
+component_name="""{root_name}"""
 )
     return render_root(component)
 
@@ -148,7 +148,7 @@ def fx_{root_name}():
 """, client_side_python="""
 {client_side_python}
 """,
-class_name="""{root_name}"""
+component_name="""{root_name}"""
 )
     return component
 

--- a/starfyre/exceptions.py
+++ b/starfyre/exceptions.py
@@ -1,0 +1,19 @@
+"""
+The exceptions module defines custom exception classes used in the application.
+
+Classes:
+    - UnknownTagError: An exception raised when encountering an unknown tag during parsing.
+
+"""
+
+class UnknownTagError(Exception):
+   """Exception raised when an unknown tag is encountered during parsing.
+
+   This exception is raised when the parser encounters a tag that is not recognized as
+   a generic HTML tag or a custom component. It indicates that the tag is unknown and
+   cannot be processed correctly.
+
+   Attributes:
+        message (str): A description of the error.
+   """
+   pass

--- a/starfyre/parser.py
+++ b/starfyre/parser.py
@@ -21,7 +21,7 @@ class RootParser(HTMLParser):
     # this is the grammar for the parser
     # we need cover all the grammar rules
 
-    generic_tags = [
+    generic_tags = {
         "html", "div", "p", "b", "span", "i", "button", "head", "link", "meta", "style", "title",
         "body", "section", "nav", "main", "hgroup", "h1", "h2", "h3", "h4", "h5", "h6",
         "header", "footer", "aside", "article", "address", "blockquote", "dd", "dl", "dt",
@@ -32,9 +32,9 @@ class RootParser(HTMLParser):
         "col", "colgroup", "table", "tbody", "td", "tfoot", "th", "thead", "tr", "datalist",
         "fieldlist", "form", "input", "label", "legend", "meter", "optgroup", "option", "output",
         "progress", "select", "textarea", "details", "dialog", "summary"
-    ]
+    }
 
-    def __init__(self, component_local_variables, component_global_variables, css, js, class_name):
+    def __init__(self, component_local_variables, component_global_variables, css, js, component_name):
         super().__init__()
         self.stack: list[tuple[Component, int]] = []
         self.children = []
@@ -50,8 +50,8 @@ class RootParser(HTMLParser):
             {**self.local_variables, **self.global_variables}
         )
         # populate the dict with the components
-        self.class_name = class_name
-        print(f'class_name={class_name}')
+        self.component_name = component_name
+        
 
     def extract_components(self, local_functions):
         components = {}
@@ -103,7 +103,6 @@ class RootParser(HTMLParser):
 
         # if the tag is not found in the generic tags but found in custom components
         if tag not in self.generic_tags and tag in self.components:
-            print(f'Tag = {tag} is not a generic BUT it is a custom component')
             component = self.components[tag]
             tag = component.tag
             component.props = {**component.props, **props}
@@ -111,14 +110,13 @@ class RootParser(HTMLParser):
             component.event_listeners = {
                 **component.event_listeners, **event_listeners}
             self.stack.append((component, self.current_depth))
-            print(f'{tag} is inside a Custom Tag. Stack is now = {self.stack}\n\n')
 
 
             return
 
         # if the tag is not found in the generic tags and custom components
         if tag not in self.generic_tags and tag not in self.components:
-            raise UnknownTagError(f'Unknown tag: "{tag}". Please review line {self.lineno} in your "{self.class_name}" component in the pyml code.')
+            raise UnknownTagError(f'Unknown tag: "{tag}". Please review line {self.lineno} in your "{self.component_name}" component in the pyml code.')
 
         component = Component(
             tag,
@@ -134,12 +132,11 @@ class RootParser(HTMLParser):
         # instead of assiging tags we assign uuids
         self.stack.append((component, self.current_depth))
         [(element[0].tag, element[1]) for element in self.stack]
-        print(f'{tag} is a Generic Tag. Stack is now = {self.stack}\n\n')
 
     def handle_endtag(self, tag):
         # if the tag is not found in the generic tags and custom components
         if tag not in self.generic_tags and tag not in self.components:             
-            raise UnknownTagError(f'Unknown tag: "{tag}". Please review line {self.lineno} in your "{self.class_name}" component in the pyml code.')
+            raise UnknownTagError(f'Unknown tag: "{tag}". Please review line {self.lineno} in your "{self.component_name}" component in the pyml code.')
 
         # we need to check if the tag is a default component or a custom component
         # if it is a custom component, we get the element from the custom components dict

--- a/test-application/parent.fyre
+++ b/test-application/parent.fyre
@@ -20,6 +20,11 @@ def ssr_request():
       <b>
         {get_parent_signal()}
       </b>
+      <ul>
+        <li>a</li>
+        <li>b</li>
+        <li>c</li>
+      </ul>
       <div> 
         This won't be re-rendered
       </div>

--- a/test-application/parent.fyre
+++ b/test-application/parent.fyre
@@ -20,11 +20,11 @@ def ssr_request():
       <b>
         {get_parent_signal()}
       </b>
-      <ulo>
+      <ul>
         <li>a</li>
         <li>b</li>
         <li>c</li>
-      </ulo>
+      </ul>
       <div> 
         This won't be re-rendered
       </div>

--- a/test-application/parent.fyre
+++ b/test-application/parent.fyre
@@ -20,11 +20,11 @@ def ssr_request():
       <b>
         {get_parent_signal()}
       </b>
-      <ul>
+      <ulo>
         <li>a</li>
         <li>b</li>
         <li>c</li>
-      </ul>
+      </ulo>
       <div> 
         This won't be re-rendered
       </div>


### PR DESCRIPTION
closes #34 
**NOTE: The print statements will be removed once I'm done debugging**

In the `handle_starttag` method, we make the parser to skip any unidentified tag that is not found in the generic tags or custom components