### PR TITLE
CLoses #39 #10 Add a way to specify the position of child components.

### DIFF
--- a/new_test/__init__.fyre
+++ b/new_test/__init__.fyre
@@ -1,0 +1,8 @@
+<pyml>
+  <span>
+    <h1> First 1 line of tag node </h1>
+    This is the first line of just text.
+    <h2> Second line 2 of tag node </h2>
+    THIS IS LAST LINE OF PLAIN TEXT.         
+  </span>   
+</pyml>

--- a/new_test/__init__.fyre
+++ b/new_test/__init__.fyre
@@ -1,8 +1,0 @@
-<pyml>
-  <span>
-    <h1> First 1 line of tag node </h1>
-    This is the first line of just text.
-    <h2> Second line 2 of tag node </h2>
-    THIS IS LAST LINE OF PLAIN TEXT.         
-  </span>   
-</pyml>

--- a/starfyre/component.py
+++ b/starfyre/component.py
@@ -25,3 +25,6 @@ class Component:
     @property
     def is_text_component(self):
         return self.tag == "TEXT_NODE"
+    
+    def __repr__(self):
+        return f"<{self.tag}> {self.data} {self.children}"

--- a/starfyre/parser.py
+++ b/starfyre/parser.py
@@ -115,8 +115,7 @@ class RootParser(HTMLParser):
 
     def handle_endtag(self, tag):
         # we need to check if the tag is a default component or a custom component
-        # if it is a custom component, we get the element from the custom components dict
-        print("test start")    
+        # if it is a custom component, we get the element from the custom components dict          
 
         if tag not in self.generic_tags and tag in self.components:
             component = self.components[tag]
@@ -126,7 +125,7 @@ class RootParser(HTMLParser):
         self.current_depth -= 1
         if endtag_node.tag != "style" and endtag_node.tag != "script":
             if len(self.stack) > 0:
-                parent_node = self.stack[-1]      #this is last item "top element" of stack
+                parent_node = self.stack[-1]      #this is last item/"top element" of stack
                 parent_node.children.append(endtag_node)
             else:
                 self.root_node = endtag_node

--- a/starfyre/parser.py
+++ b/starfyre/parser.py
@@ -23,9 +23,8 @@ class RootParser(HTMLParser):
     generic_tags = ["div", "p", "b", "span", "i", "button"]
 
     def __init__(self, component_local_variables, component_global_variables, css, js):
-        super().__init__()
-        self.stack: list[tuple[Component, int]] = []        
-        # self.stack: list[Component] = []    Suelen changes   
+        super().__init__()             
+        self.stack: list[Component] = [] 
         self.current_depth = 0
         self.css = css
         self.js = js
@@ -93,8 +92,8 @@ class RootParser(HTMLParser):
             component.props = {**component.props, **props}
             component.state = {**component.state, **state}
             component.event_listeners = {**component.event_listeners, **event_listeners}
-            # self.stack.append(component) Suelen changes
-            self.stack.append((component, self.current_depth))
+            self.stack.append(component)
+            
 
             return
 
@@ -109,10 +108,10 @@ class RootParser(HTMLParser):
             uuid=uuid4(),
         )
 
-        # instead of assiging tags we assign uuids
+        # instead of assiging tags we assign uuids        
         
-        self.stack.append((component, self.current_depth))
-        [(element[0].tag, element[1]) for element in self.stack]
+        self.stack.append(component)
+        
 
     def handle_endtag(self, tag):
         # we need to check if the tag is a default component or a custom component
@@ -122,39 +121,16 @@ class RootParser(HTMLParser):
         if tag not in self.generic_tags and tag in self.components:
             component = self.components[tag]
             tag = component.tag
-
-        endtag_node = self.stack.pop()[0]
-        # endtag_node = self.stack.pop() suelen change
+        
+        endtag_node = self.stack.pop()  
         self.current_depth -= 1
         if endtag_node.tag != "style" and endtag_node.tag != "script":
             if len(self.stack) > 0:
-                parent_node = self.stack[-1][0]       #this is last item "top element" of stack
+                parent_node = self.stack[-1]      #this is last item "top element" of stack
                 parent_node.children.append(endtag_node)
             else:
                 self.root_node = endtag_node
-                # self.children.insert(0, (endtag_node, 1))
-
-            # self.children.insert(0, (parent_node, parent_depth))
-        
-
-        # # need to check the if this is always true
-        # parent_node, parent_depth = self.stack[
-        #     -1
-        # ]  # based on the assumption that the stack is not empty
-
-        # while len(self.children) > 0:
-        #     child, child_depth = self.children[0]
-        #     if child_depth == parent_depth + 1:
-        #         self.children.pop(0)
-        #         self.stack[-1][0].children.insert(0, child)
-        #     else:
-        #         break  # we have reached the end of the children
-
-        # self.stack.pop()
-        # self.current_depth -= 1
-
-        # if parent_node.tag != "style" and parent_node.tag != "script":
-        #     self.children.insert(0, (parent_node, parent_depth))
+      
 
         print("test end")    
 
@@ -182,9 +158,8 @@ class RootParser(HTMLParser):
 
         # parsing starts here
         state = {}
+        parent_node = self.stack[-1]         
         
-        parent_node, parent_depth = self.stack[-1]
-        # parent_node = [self.stack[-1] if self.stack is [] > self.stack else 0] sueeln
         uuid = uuid4()
         component_signal = ""
 
@@ -211,8 +186,7 @@ class RootParser(HTMLParser):
                         match, self.local_variables, self.global_variables
                     )
                     if isinstance(eval_result, Component):
-                        # self.stack[-1].children.append(eval_result) suelen change
-                        self.stack[-1][0].children.append(eval_result)
+                        self.stack[-1].children.append(eval_result)
                         return
                     elif isinstance(eval_result, str):
                         current_data = eval_result
@@ -271,14 +245,11 @@ class RootParser(HTMLParser):
                 uuid=uuid,
             )
         )
-
-        # parent_node.append(wrapper_div_component)    #suelen change
+        
         parent_node.children.append(wrapper_div_component) 
 
         print(
-            "parent node",
-            # parent_node,  #suelen
-            # parent_node.children,   #suelen
+            "parent node",            
             parent_node.tag,
             parent_node.children,
             "for the text node ",

--- a/test-application/parent.fyre
+++ b/test-application/parent.fyre
@@ -11,10 +11,16 @@ def ssr_request():
 
 <pyml>
     <span>
+    
       <div>
-        {ssr_request()}
+        <h1> THIS IS MY 1 TEST </h1>
+        {ssr_request()} 
+        <p> THIS IS MY 2 TEST </p>
+        {ssr_request()} 
+        
       </div>
       <b>
+      
         {use_parent_signal()}
       </b>
       <b>
@@ -23,5 +29,6 @@ def ssr_request():
       <div> 
         This won't be re-rendered
       </div>
+      
     </span>
 </pyml>

--- a/test-application/parent.fyre
+++ b/test-application/parent.fyre
@@ -13,14 +13,12 @@ def ssr_request():
     <span>
     
       <div>
-        <h1> THIS IS MY 1 TEST </h1>
+        <h1> THIS IS MY first text node </h1>
         {ssr_request()} 
-        <p> THIS IS MY 2 TEST </p>
-        {ssr_request()} 
-        
+        <p> THIS IS MY 2second text node </p>
+        {ssr_request()}         
       </div>
-      <b>
-      
+      <b>      
         {use_parent_signal()}
       </b>
       <b>


### PR DESCRIPTION
Closes issue #39 and issue #10.

- Implemented the approach to handle children components "HTML and Text node" the same way as adding to children list of parent node to preserve order
- All HTML structure parsing is done via Stack, the code is simplified (node_depth is no longer required)
- Removed RootParser.children, replaced it with root_node reference
- Fixed issue #10 of reversing text nodes order